### PR TITLE
Distribute was merged back to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         'Topic :: Software Development :: Localization',
         'Topic :: Text Processing :: Linguistic',
     ],
-    install_requires=['distribute'],
+    install_requires=['setuptools'],
     test_suite='koreantests',
     tests_require=tests_require,
     use_2to3=(sys.version_info >= (3,)),


### PR DESCRIPTION
Distribute, which was a maintained fork of setuptools, was merged back to setuptools since it became actively maintained again.

See also: https://pythonhosted.org/setuptools/merge-faq.html.
