### PR TITLE
Update for latest Django and fix for ASCII-default envs

### DIFF
--- a/korean/__init__.py
+++ b/korean/__init__.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, unicode_literals
+import codecs
 import sys
 
 from . import hangul, l10n, morphology
@@ -35,7 +36,8 @@ def _load_data():
     """Loads allomorphic particles and number words from :file:`data.json`."""
     import json
     import os
-    with open(os.path.join(os.path.dirname(__file__), 'data.json')) as f:
+    path = os.path.join(os.path.dirname(__file__), 'data.json')
+    with codecs.open(path, 'r', encoding='utf-8') as f:
         data = json.load(f)
     # register allomorphic particles
     for forms in data['allomorphic_particles'].itervalues():

--- a/korean/__init__.py
+++ b/korean/__init__.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, unicode_literals
 import codecs
 import sys
 
+import six
+
 from . import hangul, l10n, morphology
 from .morphology import (Morpheme, Noun, NumberWord, Loanword, Particle,
                          Substantive)
@@ -40,16 +42,16 @@ def _load_data():
     with codecs.open(path, 'r', encoding='utf-8') as f:
         data = json.load(f)
     # register allomorphic particles
-    for forms in data['allomorphic_particles'].itervalues():
+    for forms in six.itervalues(data['allomorphic_particles']):
         particle = Particle(*forms)
         for form in forms:
             Particle.register(form, particle)
     # register numbers and digits
-    for number, form in data['numbers'].iteritems():
+    for number, form in six.iteritems(data['numbers']):
         NumberWord.__numbers__[int(number)] = form
-    for digit, form in data['digits'].iteritems():
+    for digit, form in six.iteritems(data['digits']):
         NumberWord.__digits__[int(digit)] = form
-    for operation, form in data['unary_operations'].iteritems():
+    for operation, form in six.iteritems(data['unary_operations']):
         NumberWord.__unary_operations__[operation] = form
 
 

--- a/korean/ext/django/__init__.py
+++ b/korean/ext/django/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+    korean.ext.django
+    ~~~~~~~~~~~~~~~~~
+
+    A Django app offering templatetags and filters for korean.
+
+    .. versionadded:: 0.1.7
+
+    .. versionchanged:: 0.1.9
+
+    .. _Django: https://www.djangoproject.com/
+
+    :copyright: (c) 2012-2013 by Heungsub Lee
+    :license: BSD, see LICENSE for more details.
+"""
+
+default_app_config = 'korean.ext.django.apps.KoreanConfig'

--- a/korean/ext/django/apps.py
+++ b/korean/ext/django/apps.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+    korean.ext.django.apps
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    A default AppConfig definition for Django 1.7+.
+
+    .. versionadded:: 0.1.9
+
+    .. _Django: https://www.djangoproject.com/
+
+    :copyright: (c) 2012-2013 by Heungsub Lee
+    :license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import, unicode_literals
+
+try:
+    from django.apps import AppConfig
+except ImportError:
+    pass
+else:
+    class KoreanConfig(AppConfig):
+        name = 'korean.ext.django'
+        label = 'korean'
+
+        def ready(self):
+            pass

--- a/korean/hangul.py
+++ b/korean/hangul.py
@@ -13,6 +13,7 @@
 """
 from __future__ import unicode_literals
 
+from six.moves import xrange
 
 __all__ = ['char_offset', 'is_hangul', 'is_vowel', 'is_consonant',
            'is_initial', 'is_final', 'get_initial', 'get_vowel', 'get_final',

--- a/korean/l10n/__init__.py
+++ b/korean/l10n/__init__.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import, unicode_literals
 from itertools import chain, product
 import re
+import six
 import warnings
 
 from ..morphology import Noun, NumberWord, Particle, pick_allomorph
@@ -77,10 +78,10 @@ class Proofreading(object):
 
 #: Default :class:`Proofreading` object. It tokenizes ``unicode`` and
 #: :class:`korean.Particle`. Use it like a function.
-proofread = Proofreading([unicode, Particle])
+proofread = Proofreading([six.text_type, Particle])
 
 
-class Template(unicode):
+class Template(six.text_type):
     """The :class:`Template` object extends :class:`unicode` and overrides
     :meth:`format` method. This can format particle format spec without
     evincive :class:`Noun` or :class:`NumberWord` arguments.
@@ -102,7 +103,7 @@ class Template(unicode):
         args = list(args)
         for seq, (key, val) in chain(product([args], enumerate(args)),
                                      product([kwargs], kwargs.items())):
-            if isinstance(val, unicode):
+            if isinstance(val, six.text_type):
                 seq[key] = Noun(val)
             elif isinstance(val, (long, int)):
                 seq[key] = NumberWord(int(val))

--- a/korean/morphology/morpheme.py
+++ b/korean/morphology/morpheme.py
@@ -9,6 +9,8 @@
 from __future__ import absolute_import, unicode_literals
 import sys
 
+import six
+
 from ..hangul import get_final, is_hangul
 
 
@@ -33,6 +35,7 @@ class MorphemeMetaclass(type):
         return super(MorphemeMetaclass, cls).__call__(*forms)
 
 
+@six.add_metaclass(MorphemeMetaclass)
 class Morpheme(object):
     """This class presents a morpheme (형태소) or allomorph (이형태). It
     can have one or more forms. The first form means the basic allomorph
@@ -42,12 +45,10 @@ class Morpheme(object):
                   allomorph.
     """
 
-    __metaclass__ = MorphemeMetaclass
-
     _registry = None
 
     def __init__(self, *forms):
-        assert all([isinstance(form, unicode) for form in forms])
+        assert all([isinstance(form, six.text_type) for form in forms])
         self.forms = forms
 
     @classmethod
@@ -64,7 +65,7 @@ class Morpheme(object):
         """Every morpheme class would implement this method. They should make a
         morpheme to the valid Korean text with Hangul.
         """
-        return unicode(self)
+        return six.text_type(self)
 
     def basic(self):
         """The basic form of allomorph."""
@@ -74,20 +75,20 @@ class Morpheme(object):
         return self.basic()
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return six.text_type(self).encode('utf-8')
 
     if sys.version_info >= (3,):
         __str__ = __unicode__
         del __unicode__
 
     def __getitem__(self, i):
-        return unicode(self)[i]
+        return six.text_type(self)[i]
 
     def __getslice__(self, start, stop, step=None):
-        return unicode(self)[start:stop:step]
+        return six.text_type(self)[start:stop:step]
 
     def __format__(self, suffix):
         return '{0!s}{1}'.format(self, suffix)
 
     def __repr__(self):
-        return '{0}({1!s})'.format(type(self).__name__, unicode(self))
+        return '{0}({1!s})'.format(type(self).__name__, six.text_type(self))

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         'Topic :: Software Development :: Localization',
         'Topic :: Text Processing :: Linguistic',
     ],
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'six'],
     test_suite='koreantests',
     tests_require=tests_require,
     use_2to3=(sys.version_info >= (3,)),


### PR DESCRIPTION
 * Django 1.7+ requires 3rd-party apps to define an AppConfig class which provides a customizable initialization point for apps in `INSTALLED_APPS` configuration.
 * In my ASCII-default environment (unfortunately this is a result of combination of uWSGI, and I currently don't know how to change that), `json.loads` causes UnicodeDecodeError with 'ascii' codec when loading data.json file. Using `codecs` to open the file with explicit encoding works.